### PR TITLE
Darken footer and add accessible link colour

### DIFF
--- a/app/components/Home/components/Body/components/Colors/components/ColorPalette/ColorPalette.js
+++ b/app/components/Home/components/Body/components/Colors/components/ColorPalette/ColorPalette.js
@@ -44,7 +44,7 @@ const getSwatch = name => {
     <div className={styles.swatch} key={name}>
       <Droplet
         color={backgroundColor}
-        sizeInRows={7}
+        sizeInRows={6}
         outline={outline !== ''}
         outlineColor={outline}
       />

--- a/app/components/Home/components/Body/components/Colors/components/ColorPalette/ColorPalette.less
+++ b/app/components/Home/components/Body/components/Colors/components/ColorPalette/ColorPalette.less
@@ -7,10 +7,10 @@
 
 .paletteTitle {
   .rawText(@heading-type-scale);
-  line-height: @grid-row-height * 7;
+  line-height: @grid-row-height * 6;
   text-align: right;
-  width: @grid-gutter-width * 6;
-  padding-right: @grid-gutter-width * 1.5;
+  width: @grid-gutter-width * 5;
+  padding-right: @grid-gutter-width;
   color: @sk-mid-gray-dark;
   flex-shrink: 0;
 }

--- a/theme/palette/accessible-variants.less
+++ b/theme/palette/accessible-variants.less
@@ -3,3 +3,4 @@
 @sk-pink-on-gray-light: #d4006b;
 @sk-learning-dark-on-gray-light: #157e00;
 @sk-business-on-gray-light: #0f749f;
+@sk-link-on-mid-gray-light: #005bb6;

--- a/theme/palette/elements.less
+++ b/theme/palette/elements.less
@@ -4,6 +4,6 @@
 @sk-focus: #1e90ff;
 @sk-highlight: #1d9ede;
 @sk-green-light: #5bc252;
-@sk-footer: #e1e1e1;
+@sk-footer: @sk-mid-gray-light;
 @sk-background: @sk-gray-light;
 @sk-yellow: #fffce3;

--- a/theme/palette/grays.less
+++ b/theme/palette/grays.less
@@ -5,6 +5,7 @@
 @sk-mid-gray-medium: #898989;
 @sk-mid-gray: #a8a8a8;
 @sk-mid-gray-light: #d6d6d6;
+@sk-gray-medium: #e1e1e1;
 @sk-gray-light: #eeeeee;
 @sk-gray-lightest: #f7f7f7;
 @sk-off-white: #fbfbfb;


### PR DESCRIPTION
Makes the footer darker to add room for a gray panel that fits between our background colour and the footer colour. As a result of the darker colour we also need an accessible variant of our link blue.

Includes updates to the style guide app for layout of the Colour Palette preview.