### PR TITLE
Export the icon component

### DIFF
--- a/react/index.js
+++ b/react/index.js
@@ -11,6 +11,7 @@ import ThumbsUpIcon from './icons/ThumbsUpIcon/ThumbsUpIcon';
 import ErrorIcon from './icons/ErrorIcon/ErrorIcon';
 import TickIcon from './icons/TickIcon/TickIcon';
 import HelpIcon from './icons/HelpIcon/HelpIcon';
+import Icon from './icons/icon';
 import Button from './Button/Button';
 import TextLink from './TextLink/TextLink';
 import PlusIcon from './icons/PlusIcon/PlusIcon';
@@ -36,6 +37,7 @@ export {
   ErrorIcon,
   TickIcon,
   HelpIcon,
+  Icon,
   Button,
   TextLink,
   PlusIcon,


### PR DESCRIPTION
I'm working on the Comm games project and we're in the process of creating a few icons for our app that (I'm told) are not appropriate / useful to have in the style guide.

We've started a new style guide project and we are adding all comm games specific styling to the project.  This project extends the seek style guide.

It'd be great for us to be able to use your `Icon` component as a base for building on top of as we create new icons for our project.  Grab me on slack (@george) if you'd like to discuss this further.