### PR TITLE
Adds values for responsive types as verified by Scott

### DIFF
--- a/theme/type/type.less
+++ b/theme/type/type.less
@@ -11,8 +11,8 @@
 // Hierarchy
 @hero-type-row-span: 5;
 @hero-type-scale: 4.2;
-@hero-type-row-span-mobile: @hero-type-row-span;
-@hero-type-scale-mobile: @hero-type-scale;
+@hero-type-row-span-mobile: 4;
+@hero-type-scale-mobile: 2.8;
 
 @headline-type-row-span: 4;
 @headline-type-scale: 2.8;


### PR DESCRIPTION
I've verified with Scott that this is the only remaining place where the desired small-screen and large-screen type sizes should differ.  If we can get this in, we can call this our baseline, and discuss adjustments to it case by case going forward, rather than thrashing while trying to re-re-re-confirm our commitment to them as a whole.

As far as I know nobody is consuming these sizes.  This PR should unblock CR from using them (it currently uses Standard but not the others).  From this point on, deviation would be our fault :)