### PR TITLE
dropdown supports hierarchy

### DIFF
--- a/app/components/App/components/Header/Header.js
+++ b/app/components/App/components/Header/Header.js
@@ -25,6 +25,7 @@ export default function Header({ title }) {
           <Link className={styles.link} activeClassName={styles.active} to="monthpicker">Month picker</Link>
           <Link className={styles.link} activeClassName={styles.active} to="checkbox">Checkbox</Link>
           <Link className={styles.link} activeClassName={styles.active} to="icons">Icons</Link>
+          <Link className={styles.link} activeClassName={styles.active} to="dropdown">Dropdown</Link>
         </div>
       </div>
     </GridContainer>

--- a/app/components/Dropdown/Dropdown.js
+++ b/app/components/Dropdown/Dropdown.js
@@ -121,7 +121,7 @@ export default class DropDownDemo extends Component {
         ]
       },
       {
-        label: 'Balarat',
+        label: 'Ballarat',
         value: '3005'
       }
     ];

--- a/app/components/Dropdown/Dropdown.js
+++ b/app/components/Dropdown/Dropdown.js
@@ -101,20 +101,31 @@ export default class DropDownDemo extends Component {
       focus,
       invalid
     });
+
     const options = [
       {
-        value: '1',
-        label: 'Developer'
+        label: 'Major Cities',
+        value: [
+          {
+            label: 'Melbourne',
+            value: '3004'
+          },
+          {
+            label: 'Sydney',
+            value: '3002'
+          }
+        ]
       },
       {
-        value: '2',
-        label: 'Tester'
+        label: 'Balarat',
+        value: '3005'
       },
       {
-        value: '3',
-        label: 'Really really long job title that is not gonna fit'
+        label: 'Really really long job title that is not gonna fit',
+        value: '3'
       }
     ];
+
     const dropdown = (
       <SeekDropDown
         id="jobTitles"

--- a/app/components/Dropdown/Dropdown.js
+++ b/app/components/Dropdown/Dropdown.js
@@ -104,6 +104,10 @@ export default class DropDownDemo extends Component {
 
     const options = [
       {
+        label: 'Really really long job title that is not gonna fit',
+        value: '3'
+      },
+      {
         label: 'Major Cities',
         value: [
           {
@@ -119,10 +123,6 @@ export default class DropDownDemo extends Component {
       {
         label: 'Balarat',
         value: '3005'
-      },
-      {
-        label: 'Really really long job title that is not gonna fit',
-        value: '3'
       }
     ];
 

--- a/react/fields/Dropdown/Dropdown.js
+++ b/react/fields/Dropdown/Dropdown.js
@@ -77,10 +77,6 @@ export default class Dropdown extends Component {
     options: PropTypes.arrayOf((propValue, key, componentName) => {
       const { value, label } = propValue[key];
 
-      if (typeof value !== 'string') {
-        return new Error(`Invalid prop \`options[${key}].value\` of type \`${typeof value}\` supplied to \`${componentName}\`, expected \`string\`.`);
-      }
-
       if (value === '') {
         return new Error(`\`options[${key}].value\` can't be an empty string.`);
       }
@@ -133,6 +129,14 @@ export default class Dropdown extends Component {
     );
   }
 
+  renderOption({ value, label }) {
+    return (<option
+      value={value}
+      key={value}
+      className={styles.option}>
+      { label }
+    </option>);
+  }
   renderSelect() {
     const { inputProps, id, options, placeholder } = this.props;
     const inputStyles = classnames({
@@ -152,14 +156,12 @@ export default class Dropdown extends Component {
           { placeholder }
         </option>
         {
-          options.map(({ value, label }) => (
-            <option
-              value={value}
-              key={value}
-              className={styles.option}>
-              { label }
-            </option>
-          ))
+          options.map(({ value, label }) => {
+            if (Array.isArray(value)) {
+              return (<optgroup value="" label={label} key={label}>{value.map(this.renderOption)}</optgroup>);
+            }
+            return this.renderOption({ value, label });
+          })
         }
       </select>
     );

--- a/react/fields/Dropdown/Dropdown.js
+++ b/react/fields/Dropdown/Dropdown.js
@@ -74,17 +74,18 @@ export default class Dropdown extends Component {
     helpProps: PropTypes.object,
     message: PropTypes.string,
     messageProps: PropTypes.object,
-    options: PropTypes.arrayOf((propValue, key, componentName) => {
-      const { value, label } = propValue[key];
-
-      if (value === '') {
-        return new Error(`\`options[${key}].value\` can't be an empty string.`);
-      }
-
-      if (typeof label !== 'string') {
-        return new Error(`Invalid prop \`options[${key}].label\` of type \`${typeof label}\` supplied to \`${componentName}\`, expected \`string\`.`);
-      }
-    }),
+    options: PropTypes.arrayOf(
+      PropTypes.shape({
+        value: PropTypes.oneOfType([
+          PropTypes.arrayOf(PropTypes.shape({
+            value: PropTypes.string,
+            label: PropTypes.string
+          })),
+          PropTypes.string
+        ]).isRequired,
+        label: PropTypes.string
+      })
+    ),
     placeholder: PropTypes.string
   };
 

--- a/react/fields/Dropdown/Dropdown.test.js
+++ b/react/fields/Dropdown/Dropdown.test.js
@@ -27,7 +27,7 @@ const options = [
 ];
 
 describe('Dropdown', () => {
-  let element, dropdown, label, input, help, message, messageIcon, placeholder, errors;
+  let element, dropdown, label, input, help, message, messageIcon, placeholder, optionGroup, childOptions, errors;
 
   beforeEach(() => {
     errors = [];
@@ -50,6 +50,8 @@ describe('Dropdown', () => {
     message = findAllWithClass(dropdown, 'message')[0] || null;
     messageIcon = findAllWithClass(dropdown, 'messageIcon')[0] || null;
     placeholder = findAllWithType(dropdown, 'option')[0] || null;
+    optionGroup = findAllWithType(dropdown, 'optgroup')[0] || null;
+    childOptions = findAllWithType(optionGroup, 'option') || null;
   }
 
   function helpText() {
@@ -77,11 +79,6 @@ describe('Dropdown', () => {
   });
 
   describe('options', () => {
-    it('should error if `options.value` is not a string', () => {
-      render(<Dropdown inputProps={{ value: '' }} options={[{ value: 2, label: '' }]} />);
-      expect(errors[0]).to.match(/Invalid prop `options\[0\].value` of type `number` supplied to `Dropdown`, expected `string`/);
-    });
-
     it('should error if `options.value` is an empty string', () => {
       render(<Dropdown inputProps={{ value: '' }} options={[{ value: '', label: '' }]} />);
       expect(errors[0]).to.match(/`options\[0\].value` can\'t be an empty string/);
@@ -90,6 +87,27 @@ describe('Dropdown', () => {
     it('should error if `options.label` is not a string', () => {
       render(<Dropdown inputProps={{ value: '' }} options={[{ value: '2', label: 2 }]} />);
       expect(errors[0]).to.match(/Invalid prop `options\[0\].label` of type `number` supplied to `Dropdown`, expected `string`/);
+    });
+  });
+
+  describe('Option Group', () => {
+    const opts = [{ label: 'suburbs', value: [{ label: 'truganina', value: '3029' }, { label: 'wl', value: '3029' }] }];
+    it('should render optgroup correctly', () => {
+      render(<Dropdown inputProps={{ value: '' }} options={opts} />);
+      expect(optionGroup.props.label).to.equal('suburbs');
+    });
+    it('should render optgroup children correctly', () => {
+      render(<Dropdown inputProps={{ value: '' }} options={opts} />);
+      expect(optionGroup.props.children.length).to.equal(2);
+    });
+    it('should render 1st optgroup child value correctly', () => {
+      render(<Dropdown inputProps={{ value: '' }} options={opts} />);
+      console.log(childOptions);
+      expect(childOptions[0].props.children).to.equal('truganina');
+    });
+    it('should render 2nd optgroup child value correctly', () => {
+      render(<Dropdown inputProps={{ value: '' }} options={opts} />);
+      expect(childOptions[1].props.children).to.equal('wl');
     });
   });
 

--- a/react/fields/Dropdown/Dropdown.test.js
+++ b/react/fields/Dropdown/Dropdown.test.js
@@ -27,7 +27,7 @@ const options = [
 ];
 
 describe('Dropdown', () => {
-  let element, dropdown, label, input, help, message, messageIcon, placeholder, optionGroup, childOptions, errors;
+  let element, dropdown, label, input, help, message, messageIcon, placeholder, optionGroup, childOptions, errors, option;
 
   beforeEach(() => {
     errors = [];
@@ -52,6 +52,7 @@ describe('Dropdown', () => {
     placeholder = findAllWithType(dropdown, 'option')[0] || null;
     optionGroup = findAllWithType(dropdown, 'optgroup')[0] || null;
     childOptions = findAllWithType(optionGroup, 'option') || null;
+    option = findAllWithType(dropdown, 'option')[1] || null;
   }
 
   function helpText() {
@@ -79,34 +80,28 @@ describe('Dropdown', () => {
   });
 
   describe('options', () => {
-    it('should error if `options.value` is an empty string', () => {
-      render(<Dropdown inputProps={{ value: '' }} options={[{ value: '', label: '' }]} />);
-      expect(errors[0]).to.match(/`options\[0\].value` can\'t be an empty string/);
-    });
-
-    it('should error if `options.label` is not a string', () => {
-      render(<Dropdown inputProps={{ value: '' }} options={[{ value: '2', label: 2 }]} />);
-      expect(errors[0]).to.match(/Invalid prop `options\[0\].label` of type `number` supplied to `Dropdown`, expected `string`/);
+    const opt = [{ label: 'suburbs', value: '3130' }];
+    it('should render options correctly', () => {
+      render(<Dropdown inputProps={{ value: '' }} options={opt} />);
+      expect(option.props.value).to.equal('3130');
     });
   });
 
   describe('Option Group', () => {
-    const opts = [{ label: 'suburbs', value: [{ label: 'truganina', value: '3029' }, { label: 'wl', value: '3029' }] }];
-    it('should render optgroup correctly', () => {
+    before(() => {
+      const opts = [{ label: 'suburbs', value: [{ label: 'truganina', value: '3029' }, { label: 'wl', value: '3029' }] }];
       render(<Dropdown inputProps={{ value: '' }} options={opts} />);
+    });
+    it('should render optgroup correctly', () => {
       expect(optionGroup.props.label).to.equal('suburbs');
     });
     it('should render optgroup children correctly', () => {
-      render(<Dropdown inputProps={{ value: '' }} options={opts} />);
       expect(optionGroup.props.children.length).to.equal(2);
     });
     it('should render 1st optgroup child value correctly', () => {
-      render(<Dropdown inputProps={{ value: '' }} options={opts} />);
-      console.log(childOptions);
       expect(childOptions[0].props.children).to.equal('truganina');
     });
     it('should render 2nd optgroup child value correctly', () => {
-      render(<Dropdown inputProps={{ value: '' }} options={opts} />);
       expect(childOptions[1].props.children).to.equal('wl');
     });
   });

--- a/react/fields/MonthPicker/NativeMonthPicker/NativeMonthPicker.js
+++ b/react/fields/MonthPicker/NativeMonthPicker/NativeMonthPicker.js
@@ -69,7 +69,7 @@ export default class NativeMonthPicker extends Component {
   }
 
   render() {
-    const { value, className, invalid, id, onBlur } = this.props;
+    const { value, className, invalid, id } = this.props;
 
     const inputValue = makeMonthString(value);
 

--- a/react/index.js
+++ b/react/index.js
@@ -29,6 +29,7 @@ export { default as Autosuggest } from './fields/Autosuggest/Autosuggest';
 export { default as Textarea } from './fields/Textarea/Textarea';
 export { default as Checkbox } from './fields/Checkbox/Checkbox';
 export { default as MonthPicker } from './fields/MonthPicker/MonthPicker';
+export { default as Dropdown } from './fields/Dropdown/Dropdown';
 
 // Accessibility
 export { default as ScreenReaderOnly } from './Accessibility/ScreenReaderOnly';

--- a/webpack.gh-pages.server.config.js
+++ b/webpack.gh-pages.server.config.js
@@ -25,7 +25,8 @@ const routes = [
   '/dropdown',
   '/checkbox',
   '/monthpicker',
-  '/typography'
+  '/typography',
+  '/dropdown'
 ];
 
 const config = {


### PR DESCRIPTION
this feature would enable the dropdown to display nested information.
optionProps supports hierarchy structure, here is one example of options:
```
const options = [
      {
        label: 'Really really long job title that is not gonna fit',
        value: '3'
      },
      {
        label: 'Major Cities',
        value: [
          {
            label: 'Melbourne',
            value: '3004'
          },
          {
            label: 'Sydney',
            value: '3002'
          }
        ]
      },
      {
        label: 'Balarat',
        value: '3005'
      }
    ]
```
<img width="973" alt="screen shot 2016-12-14 at 11 10 32 am" src="https://cloud.githubusercontent.com/assets/16127935/21164646/93f046f6-c1ee-11e6-8190-33b32b5649c7.png">

