### PR TITLE
fix textarea help style

### DIFF
--- a/react/fields/Textarea/Textarea.less
+++ b/react/fields/Textarea/Textarea.less
@@ -57,7 +57,6 @@
 .footer {
   display: flex;
   justify-content: space-between;
-  align-items: center;
   min-height: (@grid-row-height * @standard-type-row-span);
   margin-bottom: @grid-row-height;
   align-items: flex-start;

--- a/react/fields/Textarea/Textarea.less
+++ b/react/fields/Textarea/Textarea.less
@@ -60,6 +60,7 @@
   align-items: center;
   min-height: (@grid-row-height * @standard-type-row-span);
   margin-bottom: @grid-row-height;
+  align-items: flex-start;
 }
 
 .help {
@@ -90,6 +91,7 @@
   .standardText();
   color: @sk-mid-gray-dark;
   text-align: right;
+  margin-left: (@grid-gutter-width / 2);
 
   &:only-child {
     flex-basis: 100%;


### PR DESCRIPTION
fixes in this PR:
- fix to avoid the count number being wrapped to a new line.

issue:
![image](https://cloud.githubusercontent.com/assets/16127935/21830953/7866e310-d7f4-11e6-9d8a-4f29217259fb.png)

- add more space between the help text and the count, since given some specific resolution, the help text and count will be joined together.

issue:
![image](https://cloud.githubusercontent.com/assets/16127935/21830944/64b546f4-d7f4-11e6-8b1f-82b2a48f4ffd.png)


